### PR TITLE
feat: support binary response pass-through (isBase64Encoded)

### DIFF
--- a/src/lib/lambda-route-proxy-entry-handler.ts
+++ b/src/lib/lambda-route-proxy-entry-handler.ts
@@ -202,7 +202,24 @@ export const lambdaRouteProxyEntryHandler =
 
         retVal = await getRouteModuleResult(routeModule, routeArgs);
 
-        if (isProxied) {
+        // Binary pass-through: if the handler explicitly sets isBase64Encoded: true,
+        // the response is a pre-formed API Gateway response (binary proxy, file download, etc.).
+        // Pass it through without JSON-wrapping or header overriding.
+        if (retVal.isBase64Encoded === true) {
+          // Merge CORS + security headers beneath handler-provided headers so binary
+          // endpoints still get proper CORS without having to set them manually.
+          const requestOrigin = event.headers?.origin || event.headers?.Origin;
+          const corsHeaders = generateCorsHeaders(securityConfig, requestOrigin);
+          retVal = {
+            ...retVal,
+            headers: {
+              ...securityConfig.defaultHeaders,
+              ...corsHeaders,
+              ...(routeArgs.responseHeaders ?? {}),
+              ...(retVal.headers ?? {}),
+            },
+          };
+        } else if (isProxied) {
           if (retVal.statusCode && !retVal.body) {
             console.log("body must be included when status code is set", retVal);
             throw new CustomError("No body found", 500);


### PR DESCRIPTION
## Summary

Handlers that return `isBase64Encoded: true` now bypass the JSON-wrapping logic in the entry handler. The response is passed through to API Gateway as-is, with CORS and security headers merged beneath handler-provided headers.

## Use Case

Binary proxy endpoints (image/video pass-through, file downloads) that return pre-formed API Gateway responses with base64-encoded bodies. Previously, the framework would override `isBase64Encoded` to `false` and force `Content-Type: application/json`, breaking binary responses.

## Changes

- `lambda-route-proxy-entry-handler.ts`: Added a check at the top of the response-processing block. If `retVal.isBase64Encoded === true`, the response passes through with only CORS/security headers merged (lowest priority — handler headers win).

## Testing

- All 17 existing tests pass
- TypeScript compiles clean
- Build succeeds